### PR TITLE
Create netlify.toml for deployment to netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+    publish = "dist"
+    command = "gridsome build"


### PR DESCRIPTION
gridsome creates a "dist" folder instead of "_site"
and also "gridsome build" is used instead of "npm run build" to create static site in netlify